### PR TITLE
Change edc_state to publish_state

### DIFF
--- a/ckanext/edc_rss/controllers/rss.py
+++ b/ckanext/edc_rss/controllers/rss.py
@@ -25,7 +25,7 @@ class RSSController(base.BaseController):
 
         data_dict = {
             'q' : '+metadata_visibility:Public',
-            'fq': '+edc_state:("PUBLISHED" OR "PENDING ARCHIVE")',
+            'fq': '+publish_state:("PUBLISHED" OR "PENDING ARCHIVE")',
             'start': 0,
             'rows': 50,
             'sort': 'record_publish_date desc, metadata_modified desc',


### PR DESCRIPTION
The new UI's schema replaces edc_state with publish_state. This change fixes the RSS feeds in beta.